### PR TITLE
issue-20: replace JDoodle with Piston

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -127,14 +127,12 @@ This is an example of how to list things you need to use the software and how to
     GOOGLE_KEY_CLIENTSECRET= https://console.cloud.google.com/apis/credentials
     TWITTER_KEY_CONSUMERKEY = https://developer.twitter.com/en/portal/projects
     TWITTER_KEY_CONSUMERSECRET =https://developer.twitter.com/en/portal/projects
-    JDOODLE_CLIENTID=https://www.jdoodle.com/
-    JDOOLDE_CLIENTSECRET= https://www.jdoodle.com/
     COOKIE_KEYS= your-cookie-secrert
     PROD= false
     DATABASE_URL = postgresql://postgres:password@localhost:5432/rtce
     CLIENT_URL = http://localhost:3000
-    JDOODLE_URL = https://api.jdoodle.com/v1/execute
     SERVER_URL = http://localhost:5000
+    PISTON_URL= https://emkc.org/api/v2/piston
    ```
 
 ## Roadmap

--- a/src/config.keys.ts
+++ b/src/config.keys.ts
@@ -28,11 +28,6 @@ export const TWITTER_KEY: Record<string, string> = {
   consumerSecret: process.env.TWITTER_KEY_CONSUMERSECRET!,
 };
 
-export const JDOODLE = {
-  clientID: process.env.JDOODLE_CLIENTID,
-  clientSecret: process.env.JDOOLDE_CLIENTSECRET,
-};
-
 export const PROD: boolean = JSON.parse(process.env.PROD!);
 
 export const port = parseInt(<string>process.env.PORT) || 5000;
@@ -43,4 +38,4 @@ export const CLIENT_URL = process.env.CLIENT_URL || "http://localhost:5000";
 
 export const COOKIE_KEYS = [process.env.COOKIE_KEYS!];
 
-export const JDOODLE_URL = process.env.JDOODLE_URL!;
+export const PISTON_URL = process.env.PISTON_URL;

--- a/src/routes/api-routes.ts
+++ b/src/routes/api-routes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import axios from "axios";
-import { JDOODLE, JDOODLE_URL } from "../config.keys";
+import { PISTON_URL } from "../config.keys";
 import { getLanguageVersion, getLanguage } from "../utils/getLanguageVersion";
 import { filterQuestions, renderQuestion } from "../utils/databaseQueries";
 import { scrapeQuestion } from "../utils/scrapeQuestion";
@@ -60,33 +60,37 @@ router.post("/execute", async (req, res) => {
     });
   }
 
-  const response = await axios({
-    method: "POST",
-    url: `${JDOODLE_URL}/execute`,
-    data: {
-      script: script,
-      stdin: stdin,
-      language: getLanguage[language],
-      versionIndex: getLanguageVersion[language],
-      clientId: JDOODLE.clientID,
-      clientSecret: JDOODLE.clientSecret,
-    },
-    responseType: "json",
-  });
-  res.json(response.data);
-});
+  const data = {
+    language: getLanguage[language],
+    version: getLanguageVersion[getLanguage[language]],
+    files: [
+      {
+        content: script,
+      },
+    ],
+    stdin: stdin,
+  };
 
-router.get("/credit-spent", async (req, res) => {
-  const response = await axios({
-    method: "POST",
-    url: `${JDOODLE_URL}/credit-spent`,
-    data: {
-      clientId: JDOODLE.clientID,
-      clientSecret: JDOODLE.clientSecret,
-    },
-    responseType: "json",
-  });
-  res.json(response.data);
+  try {
+    const response = await axios({
+      method: "POST",
+      url: `${PISTON_URL}/execute`,
+      data: data,
+      responseType: "json",
+    });
+
+    const responseData = {
+      output: response.data.run.output,
+      statusCode: 200,
+    };
+
+    res.status(200).json(responseData);
+  } catch (e) {
+    res.status(500).json({
+      message: "Error sending request",
+      error: e,
+    });
+  }
 });
 
 export default router;

--- a/src/utils/getLanguageVersion.ts
+++ b/src/utils/getLanguageVersion.ts
@@ -1,18 +1,18 @@
 export const getLanguageVersion: Record<string, string> = {
-  cpp17: "0", // g++ 17 GCC 9.10
-  java: "3", // JDK 11.0.4
-  python3: "3", // 3.7.4
-  go: "3", // 1.13.1
-  nodejs: "3", // 12.11.1
-  ruby: "3", // 2.6.5
-  haskell: "3", // ghc 8.6.5
-  rust: "3", // 1.38.0
-  php: "3", // 7.3.10
+  cpp: "10.2.0", // g++ 17 GCC 9.10
+  java: "15.0.2", // JDK 11.0.4
+  python3: "3.10.0", // 3.7.4
+  go: "1.16.2", // 1.13.1
+  "node-javascript": "16.3.0", // 12.11.1
+  ruby: "3.0.1", // 2.6.5
+  haskell: "9.0.1", // ghc 8.6.5
+  rust: "1.50.0", // 1.38.0
+  php: "8.0.2", // 7.3.10
 };
 export const getLanguage: Record<string, string> = {
-  "text/x-c++src": "cpp17",
+  "text/x-c++src": "cpp",
   "text/x-java": "java",
-  "text/javascript": "nodejs",
+  "text/javascript": "node-javascript",
   "text/x-python": "python3",
   "text/x-go": "go",
   "text/x-rustsrc": "rust",


### PR DESCRIPTION
Resolves https://github.com/Rishabh-malhotraa/caucus/issues/20

1. Removed references to JDoodle 
2. Replace `/execute` endpoint with a call to Piston
3. Update `src\utils\getLanguageVersion.ts` with values from https://emkc.org/api/v2/piston/runtimes

I tested this by running https://github.com/Rishabh-malhotraa/caucus locally and running code for all the available languages